### PR TITLE
Add symlink to diamond collectors path on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 dist: trusty
 python:
   - "2.7"
+before_install:
+  - sudo ln -s $TRAVIS_BUILD_DIR/.tox/py27/share/diamond /usr/share/diamond
 install:
   - "pip install tox-travis"
   - "pip install setuptools-markdown"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ pkg:
 	$(MAKE) clean
 	bash -c "./scripts/pkg.sh snap_diamond snap-plugin-collector-diamond"
 test:
-	py.test --cov=snap_diamond tests
+	tox
 clean:
 	rm -rf dist .venv *.egg-info build .acbuild
 	find . -name '*.pyc' -exec rm --force {} \;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ consumed by [Snap](http://github.com/intelsdi-x/snap).
 * Linux
 * Required if building the the plugin package
   * [acbuild](https://github.com/containers/build) required for create a package
-  * virtualenv or pyenv (see: [virtualenv primer](https://realpython.com/blog/python/python-virtual-environments-a-primer/))
+  * [pyenv](https://github.com/pyenv/pyenv)
+* Required for testing plugin
+  * [tox](https://tox.readthedocs.io/en/latest/) (install using `pip install tox`)
 
 ### Installation
 
@@ -38,15 +40,7 @@ You will need to be on Linux with Python 2.7 or Python3 and a virtualenv activat
 
 To build package with virtual environment included you will need [pyenv](https://github.com/pyenv/pyenv) installed on your system.
 
-Run the following commands from the root of the repository.
-
-Install the Python deps:
-`pip install -r requirements.txt`
-
-Create the plugin package:
-`scripts/pkg.sh`
-
-Package will be available under "dist" folder.
+Just run the `make pkg` command to build ACI package. Package file will be available under "dist" folder.
 
 ### Example
 

--- a/snap_diamond/__init__.py
+++ b/snap_diamond/__init__.py
@@ -184,7 +184,6 @@ class DiamondCollector(snap.Collector):
                 diamond_collector_cfg = diamond_cfg["collectors"]
                 for collector_name in diamond_collector_cfg:
                     snap.LOG.debug("Found '%s' plugin configuration", collector_name)
-                    snap.LOG.warning(config["collectors_path"])
                     module_name = collector_name.replace("Collector", "").lower()
                     # update path
                     sys.path.append("{}/{}".format(config["collectors_path"], module_name))


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Summary of changes:
- Add symlink to diamond collectors path in tox virtual env to be available under default /usr/share/diamond/collectors
- Set tox as default unit test command
- Update documentation