### PR TITLE
General cleanup and preparation for Travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ before_install:
   - sudo ln -s $TRAVIS_BUILD_DIR/.tox/py27/share/diamond /usr/share/diamond
 install:
   - "pip install tox-travis"
-  - "pip install setuptools-markdown"
 script: make test
 before_deploy:
   - make pkg
 deploy:
   - provider: s3
-    access_key_id: $AWS_KEY_ID
+    access_key_id: $AWS_ACCESS_KEY_ID
     secret_access_key: $AWS_SECRET_ACCESS_KEY
     bucket: snap.ci.snap-telemetry.io
     region: us-west-2
@@ -22,7 +21,7 @@ deploy:
     upload-dir: plugins
     acl: public_read
     on:
-      repo: intelsdi-x/snap-plugin-collector-pysmart
+      repo: intelsdi-x/snap-plugin-collector-diamond
       tags: true
   - provider: pypi
     distributions: sdist bdist_wheel
@@ -31,7 +30,7 @@ deploy:
     password: $PYPI_PASSWORD
     on:
       tags: true
-      repo: intelsdi-x/snap-plugin-collector-pysmart
+      repo: intelsdi-x/snap-plugin-collector-diamond
   - provider: releases
     api_key: $GITHUB_API_KEY
     file:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include snap_diamond/_version.py
+include README.rst

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ consumed by [Snap](http://github.com/intelsdi-x/snap).
 
 ### System requirements
 
-* Python2 (>=2.7) or Python3
+* Python2 (>=2.7)
 * Linux
 * Required if building the the plugin package
   * [acbuild](https://github.com/containers/build) required for create a package

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,7 @@
+Snap Plugin Collector Diamond
+=============================
+
+This is plugin for `Snap telemetry framework <http://snap-telemetry.io/>`_.
+For overview of Snap checkout its GitHub repo `here <https://github.com/intelsdi-x/snap>`_.
+
+For more information about this plugin visit its `repo <http://github.com/intelsdi-x/snap-plugin-collector-diamond>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 snap-plugin-lib-py>=1.0.10,<2
 diamond>=4.0.515
-configobj>=5.0.6
 psutil>=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,21 +18,26 @@
 from setuptools import setup, find_packages
 import versioneer
 
+
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
 setup(
     name="snap-plugin-collector-diamond",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-    install_requires=['snap-plugin-lib-py>=1.0.10,<2', 'diamond>=4.0.515', 'configobj>=5.0.6', 'psutil>=5.0.0'],
+    install_requires=['snap-plugin-lib-py>=1.0.10,<2', 'diamond>=4.0.515', 'psutil>=5.0.0'],
     author="Joel Cooklin",
     author_email="joel.cooklin@gmail.com",
-    description="This snap plugin wraps Diamond plugins so they can be easily consumed by Snap.",
-    entry_points = {
+    description="This is a plugin for the Snap telemetry framework wrapping Diamond daemon plugins.",
+    entry_points={
         'console_scripts': [
             'snap-plugin-collector-diamond=snap_diamond.plugin:run'
         ]
     },
-    long_description_markdown_filename="README.md",
+    long_description=readme(),
     license="Apache 2.0",
     keywords="snap telemetry plugin plugins metrics diamond",
     url="http://github.com/intelsdi-x/snap-plugin-collector-diamond"

--- a/snap_diamond/__init__.py
+++ b/snap_diamond/__init__.py
@@ -117,7 +117,7 @@ class DiamondCollector(snap.Collector):
                 instance.
             3c. The plugin_instance is stored saved for future use.
 
-        On update_catallog:
+        On update_catalog:
             After initialization we loop over the enabled diamond plugins
             calling collect.  The SnapHandler is automatically called for every
             collect call which transforms the metrics into snap.Metric.  After

--- a/snap_diamond/plugin.py
+++ b/snap_diamond/plugin.py
@@ -20,9 +20,9 @@
 import re
 
 import snap_plugin.v1 as snap
-from pkg_resources import get_distribution
+from pkg_resources import get_distribution, DistributionNotFound
 
-import snap_diamond
+from snap_diamond import __version__, DiamondCollector
 
 PACKAGE_NAME = "snap-plugin-collector-diamond"
 
@@ -34,16 +34,22 @@ def get_plugin_version(name):
     :param name: The name of package
     :return: Major version number
     """
-    _ver = re.search('^(\d+).*$', get_distribution(name).version)
+
+    try:
+        _pkg_ver = get_distribution(name).version
+    except DistributionNotFound:
+        _pkg_ver = __version__
+
+    _ver = re.search('^(\d+).*$', _pkg_ver)
     if _ver and len(_ver.groups()) > 0:
         return int(_ver.groups()[0])
     return 1
 
 
 def run():
-    snap_diamond.DiamondCollector("diamond", get_plugin_version(PACKAGE_NAME), exclusive=True,
-                                  routing_strategy=snap.plugin.RoutingStrategy.sticky,
-                                  concurrency_count=1).start_plugin()
+    DiamondCollector("diamond", get_plugin_version(PACKAGE_NAME), exclusive=True,
+                     routing_strategy=snap.plugin.RoutingStrategy.sticky,
+                     concurrency_count=1).start_plugin()
 
 
 if __name__ == "__main__":

--- a/tests/test_snap_diamond.py
+++ b/tests/test_snap_diamond.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 
 import snap_plugin.v1 as snap
-import sys
-import os
 import time
 from snap_diamond import DiamondCollector
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 envlist = py27
-; recreate = True
+recreate = True
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Summary of changes:

- Removed files needed for PyPI - plugin is an application, not a library and isn't meant to be distributed by PyPI - instead, releases will be automated with Travis and pushed to GitHub
- General cleanup